### PR TITLE
Allow get-task-allow entitlement on release versions of dolphin

### DIFF
--- a/Source/Core/DolphinQt/DolphinEmu.entitlements
+++ b/Source/Core/DolphinQt/DolphinEmu.entitlements
@@ -16,5 +16,8 @@
 	<!-- Allows the Steam overlay library to be injected into our process -->
 	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
 	<true/>
+	<!-- This is needed to attach a debugger to the process or to view the memory with an external tool such a dolphin-memory-engine -->
+	<key>com.apple.security.get-task-allow</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Windows let you debug dolphin on the stock version of dolphin, why not macOS